### PR TITLE
検索用にDate型をStringに変換する

### DIFF
--- a/src/la/DAO/TrainingDAO.java
+++ b/src/la/DAO/TrainingDAO.java
@@ -72,7 +72,7 @@ public class TrainingDAO {
             st.setInt(2, areaId);
 
             // 2019-06-01 19:00:00のような文字列にフォーマットを整える
-            DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
+            DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
             LocalDateTime dateTimeData = LocalDateTime.parse(date, dtf);
             String dateTimeDataStr = dateTimeData.toString();
             st.setString(3, dateTimeDataStr);

--- a/src/la/DAO/TrainingDAO.java
+++ b/src/la/DAO/TrainingDAO.java
@@ -71,10 +71,11 @@ public class TrainingDAO {
             st.setInt(1, muscleCategoryId);
             st.setInt(2, areaId);
 
-            // TODO: String DateをDateTimeに変更する
+            // 2019-06-01 19:00:00のような文字列にフォーマットを整える
             DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
             LocalDateTime dateTimeData = LocalDateTime.parse(date, dtf);
-            st.setDate(3, dateTimeData);
+            String dateTimeDataStr = dateTimeData.toString();
+            st.setString(3, dateTimeDataStr);
 
             rs = st.executeQuery();
             List<TrainingBean> list = new ArrayList<>();


### PR DESCRIPTION
TRAININGテーブルのDATEカラムで検索できるようにした。

STRING型で検索するので、サーブレットから渡ってきたデータ（String date）を、検索できるように
`yyyy-MM-dd HH:mm:ss`に変換する。
